### PR TITLE
Carve2

### DIFF
--- a/pkgs/development/tools/carve/default.nix
+++ b/pkgs/development/tools/carve/default.nix
@@ -1,0 +1,51 @@
+{ clojure, fetchFromGitHub, lib, graalvm11-ce, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "carve";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "borkdude";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1yijjxhkl4hln4f2q2z20bpwmqn5brsi8l0iw8968nmh9s9qy1vq";
+  };
+
+  nativeBuildInputs = [ clojure graalvm11-ce ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Cannot create directory /homeless-shelter/.... Error: FILE_ERROR_ACCESS_DENIED
+    export HOME=$TMPDIR
+
+    # https://github.com/borkdude/carve/blob/a3a5b941d4327127e36541bf7322b15b33260386/script/compile#L10-L25
+    clojure -Sdeps "$(cat $src/deps.edn)" -J-Dclojure.compiler.direct-linking=true -X:native:uberjar
+    args=("-cp" "carve.jar"
+          "-H:Name=${pname}"
+          "-H:+ReportExceptionStackTraces"
+          "--initialize-at-build-time"
+          "-H:EnableURLProtocols=jar"
+          "--report-unsupported-elements-at-runtime"
+          "--verbose"
+          "--no-fallback"
+          "--no-server"
+          "-J-Xmx3g"
+          "carve.main")
+     native-image ''${args[@]}
+     runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp carve $out/bin/carve
+  '';
+
+  meta = with lib; {
+    description = "Searches through Clojure code for unused vars and removes them";
+    homepage = "https://github.com/borkdude/carve";
+    license = licenses.epl10;
+    platforms = graalvm11-ce.meta.platforms;
+    maintainers = with maintainers; [ john-shaffer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -222,6 +222,8 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  carve = callPackage ../development/tools/carve { };
+
   castget = callPackage ../applications/networking/feedreaders/castget { };
 
   castxml = callPackage ../development/tools/castxml {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
